### PR TITLE
Truncating long commit messages to 1024 chars

### DIFF
--- a/lib/heirloom/archive/builder.rb
+++ b/lib/heirloom/archive/builder.rb
@@ -52,7 +52,7 @@ module Heirloom
     def add_git_commit_to_artifact_record(commit)
       attributes = { 'sha'             => @id,
                      'abbreviated_sha' => commit.id_abbrev,
-                     'message'         => commit.message.gsub("\n"," "),
+                     'message'         => commit.message.gsub("\n"," ")[0..1023],
                      'author'          => commit.author.name }
 
       attributes.each_pair do |k, v|

--- a/spec/archive/builder_spec.rb
+++ b/spec/archive/builder_spec.rb
@@ -70,6 +70,23 @@ describe Heirloom::Builder do
                          :git       => 'true').should == '/var/tmp/file.tar.gz'
         end
 
+        it "should truncate commit message to 1024 chars" do
+          long_commit_message = 'long commit message' * 100
+          truncated_commit_attributes = { 'sha'             => '123',
+                                          'abbreviated_sha' => 'abc123',
+                                          'message'         => long_commit_message[0..1023],
+                                          'author'          => 'weaver' }
+          @simpledb_mock.should_receive(:put_attributes).
+                         with('heirloom_tim', '123', truncated_commit_attributes)
+          @git_commit_stub = stub :id_abbrev => "abc123",
+                                  :message   => long_commit_message,
+                                  :author    => @author_stub
+          @git_dir_mock.stub :commit => @git_commit_stub
+          @builder.build(:exclude   => ['.dir_to_exclude'],
+                         :directory => 'path_to_build',
+                         :git       => 'true').should == '/var/tmp/file.tar.gz'
+        end
+
       end
 
       context "without git dir" do


### PR DESCRIPTION
This is needed because 1024 is the maximum length allowed in a SimpleDB
column. Commit messages can be very long with doing a squashed commit
of a long running feature branch.

Here is a failed build due to the bug: http://ci.intuit-lc.com/job/live_community/492/console
